### PR TITLE
Check result first before adding it to accumulated array

### DIFF
--- a/src/lib/performSeoReview.js
+++ b/src/lib/performSeoReview.js
@@ -115,10 +115,10 @@ export default async function performSeoReview(url, keyword, synonyms) {
         const newArr = Object.keys(assessmentResults[parentCur]).reduce((childAcc, childKey) => {
           const newChild = assessmentResults[parentCur][childKey]
 
-          return [...childAcc, newChild]
+          return newChild ? [...childAcc, newChild] : childAcc
         }, [])
 
-        return [...parentAcc, ...newArr]
+        return newArr ? [...parentAcc, ...newArr] : parentAcc
       }, [])
 
       // mapResults function is a lightly edited function copied from the Yoast WordPress plugin


### PR DESCRIPTION
There are many ways to attack this. This is rather a quick patch to make sure that the array we're accumulating via `reduce` function don't ever get a `null` value.