### PR TITLE
Add async support to options, moving into SeoPaneComponent

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,18 +25,24 @@ import SeoPane from 'sanity-plugin-seo-pane'
 S.view
   .component(SeoPane)
   .options({
+    // Retrieve the keywords and synonyms at the given dot-notated strings
     keywords: `seo.keywords`,
     synonyms: `seo.synonyms`,
     url: (doc) => resolveProductionUrl(doc),
+
+    // Alternatively, specify functions (may be async) to extract values
+    // keywords: doc => doc.seo?.keywords,
+    // synonyms: async(doc) => client.fetch('some query to get synonyms', {id: doc._id}),
+    // url: async(doc) => client.fetch('some query to construct a url with refs', {id: doc._id})
   })
   .title('SEO')
 ```
 
 The `.options()` configuration works as follows:
 
-- `keywords` (string, required) A [dot-notated string](https://www.npmjs.com/package/dlv) from the document object to a field containing the keywords/keyphrase.
-- `synonyms` (string, optional) As above.
-- `url` (function, required) A function that takes in the current document, and should return a string with a URL to a preview-enabled front-end. You likely have a function like this already for Live Preview.
+- `keywords` (`string|function(Document):(string|Promise<string>)`, required) Either a [dot-notated string](https://www.npmjs.com/package/dlv) from the document object to a field containing the keywords/keyphrase, or a function that resolves to the keywords/keyphrase in the document object.
+- `synonyms` (`string|function(Document):(string|Promise<string>)`, optional) As above.
+- `url` (`function(Document):(string|Promise<string>)`, required) A function that takes in the current document, and resolves to a string with a URL to a preview-enabled front-end. You likely have a function like this already for Live Preview.
 
 ### Defining the content area
 

--- a/src/ErrorStack.js
+++ b/src/ErrorStack.js
@@ -1,0 +1,15 @@
+import React, { useState } from 'react'
+
+export default function ErrorStack ({ stack }) {
+  const [visible, setVisible] = useState(false)
+
+  return !stack ? null : (
+    <div>
+      <a href="#" onClick={setVisible.bind(null, !visible)}
+        style={{ display: 'block', fontSize: '75%', marginTop: '1rem' }}>
+        {visible ? 'Hide' : 'Show'} Stack Trace
+      </a>
+      {visible && <pre style={{ fontSize: '75%' }}>{stack}</pre>}
+    </div>
+  )
+}

--- a/src/SeoPane.js
+++ b/src/SeoPane.js
@@ -1,57 +1,19 @@
 import React from 'react'
 import {studioTheme, ThemeProvider} from '@sanity/ui'
 import PropTypes from 'prop-types'
-import delve from 'dlv'
 import {QueryClientProvider, QueryClient} from 'react-query'
 
 import SeoPaneComponent from './SeoPaneComponent'
-import Feedback from './Feedback'
 
 const queryClient = new QueryClient()
 
-function ThemeWrapper({children}) {
-  return <ThemeProvider theme={studioTheme}>{children}</ThemeProvider>
-}
-
-function SeoPane({document: sanityDocument, options}) {
-  const {displayed} = sanityDocument
-  const {_id, _rev} = displayed
-
-  if (!_id) {
-    return (
-      <ThemeWrapper>
-        <Feedback isError>Document is not Published</Feedback>
-      </ThemeWrapper>
-    )
-  }
-
-  if (!options.keywords) {
-    return (
-      <ThemeWrapper>
-        <Feedback isError>Keyword is not defined</Feedback>
-      </ThemeWrapper>
-    )
-  }
-
-  const keywords = delve(displayed, options.keywords)
-  const synonyms = delve(displayed, options.synonyms)
-
-  if (!options.url) {
-    return (
-      <ThemeWrapper>
-        <Feedback isError>URL is not defined</Feedback>
-      </ThemeWrapper>
-    )
-  }
-
-  const url = options.url(displayed)
-
+export default function SeoPane ({ document: { displayed }, options }) {
   return (
-    <ThemeWrapper>
+    <ThemeProvider theme={studioTheme}>
       <QueryClientProvider client={queryClient}>
-        <SeoPaneComponent revision={_rev} keywords={keywords} synonyms={synonyms} url={url} />
+        <SeoPaneComponent document={displayed} options={options} />
       </QueryClientProvider>
-    </ThemeWrapper>
+    </ThemeProvider>
   )
 }
 
@@ -63,10 +25,8 @@ SeoPane.propTypes = {
     }),
   }).isRequired,
   options: PropTypes.shape({
-    keywords: PropTypes.string,
-    synonyms: PropTypes.string,
-    url: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+    keywords: PropTypes.oneOfType([PropTypes.string, PropTypes.func]).isRequired,
+    synonyms: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+    url: PropTypes.func.isRequired,
   }).isRequired,
 }
-
-export default SeoPane

--- a/src/SeoPaneComponent.js
+++ b/src/SeoPaneComponent.js
@@ -31,8 +31,8 @@ export default function SeoPaneComponent({document, options}) {
       ])
 
       // Visits document path when strings because the asyncCall will have same value as options
-      if (keywords && keywords === options.keywords) keywords = delve(keywords, document)
-      if (synonyms && synonyms === options.synonyms) synonyms = delve(synonyms, document)
+      if (keywords && keywords === options.keywords) keywords = delve(document, keywords)
+      if (synonyms && synonyms === options.synonyms) synonyms = delve(document, synonyms)
 
       // Tack on keywords and synonyms to seo review response since we use them.
       return {

--- a/src/SeoPaneComponent.js
+++ b/src/SeoPaneComponent.js
@@ -10,6 +10,7 @@ import performSeoReview from './lib/performSeoReview'
 import {renderRatingToColor} from './lib/renderRatingToColor'
 import {resultsLabels} from './lib/resultsLabels'
 
+import ErrorStack from './ErrorStack.js'
 import Feedback from './Feedback'
 
 export default function SeoPaneComponent({document, options}) {
@@ -53,13 +54,15 @@ export default function SeoPaneComponent({document, options}) {
   }
 
   // Bail out on error. Unfortunately can't JSON.stringify(Error) to get the stack/message.
-  let errorMessage;
-  if (error instanceof Error) errorMessage = error.stack ? <pre>{error.stack}</pre> : error.message;
-  else if (!data) errorMessage = 'Empty response';
-  else if (data.error) errorMessage = <pre>{JSON.stringify(data.error)}</pre>;
+  let errorMessage
+  if (error instanceof Error) {
+    errorMessage = <>{error.message} <ErrorStack stack={error.stack} /></>
+  }
+  else if (!data) errorMessage = 'Empty response'
+  else if (data.error) errorMessage = <pre>{JSON.stringify(data.error)}</pre>
 
   if (errorMessage) {
-    return <Feedback isError>Error: {errorMessage}</Feedback>;
+    return <Feedback isError>Error: {errorMessage}</Feedback>
   }
 
   const {keywords, meta, permalink, resultsMapped, synonyms} = data

--- a/src/lib/asyncCall.js
+++ b/src/lib/asyncCall.js
@@ -1,0 +1,9 @@
+/**
+ * Call item asynchronously if it is a function, otherwise return itself.
+ * @param {any} item Potentially callable, possibly async function or promise.
+ * @param  {...any} args Arguments to be applied to item if it is a function.
+ * @returns {any} Result of promise, async/sync function, or the item if not a function.
+ */
+export default async function asyncCall (item, ...args) {
+  return await (typeof item === 'function' ? item.apply(this, args) : item)
+}


### PR DESCRIPTION
For simplicity sake, this makes options.url, options.keywords, options.synonyms all support `string`, `function:string`, and `function:Promise<string>` values, however, I tried to respect the configuration as noted in the README, not the PropTypes, for url since a fixed string doesn't seem very useful anyway.

Not 100% sure if this actually works as expected as I am still in the process of integrating this into my own studio, but I figure you can give a big 👎 if you have something else in mind, or if it is what you did have in mind and it actually works, then, you know go for it.